### PR TITLE
GetFunctionCallInfo() from funcCallQuery instead

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Auto detect text files and perform LF normalization
+* text=auto

--- a/include/ProfilingHook.h
+++ b/include/ProfilingHook.h
@@ -22,8 +22,10 @@ namespace Profiling {
         ProfilingHook& operator=(ProfilingHook&&) = delete;
     };
 
-    static RE::BSFixedString* FuncCallHook(std::uint64_t unk0, RE::BSScript::Stack* a_stack,
-                                           std::uint64_t* a_funcCallQuery);
+    static RE::BSFixedString* FuncCallHook(
+        RE::BSScript::Internal::VirtualMachine* _this,
+        RE::BSScript::Stack* a_stack,
+        RE::BSTSmartPointer<RE::BSScript::Internal::IFuncCallQuery>& a_funcCallQuery);
 
     static inline REL::Relocation<decltype(FuncCallHook)> _original_func;
     static std::unique_ptr<spdlog::logger> outputLogger;

--- a/src/Main.cpp
+++ b/src/Main.cpp
@@ -55,7 +55,17 @@ namespace {
  */
 SKSEPluginLoad(const LoadInterface* skse) {
     InitializeLogging();
+// just define this in the CXX flags if you want it to wait for a debugger to attach before the game loads
+#ifdef _DEBUG_WAIT_FOR_ATTACH
+    log::info("Waiting for debugger to attach...");
+    while (!IsDebuggerPresent())
+    {
+        Sleep(10);
+    }
 
+    Sleep(1000 * 4);
+    logger::info("Debugger attached!");
+#endif
     auto* plugin = PluginDeclaration::GetSingleton();
     auto version = plugin->GetVersion();
     log::info("{} {} is loading...", plugin->GetName(), version);

--- a/src/ProfilingHook.cpp
+++ b/src/ProfilingHook.cpp
@@ -13,6 +13,11 @@ void ProfilingHook::InstallHook() {
     auto& trampoline = SKSE::GetTrampoline();
     SKSE::AllocTrampoline(14);
 
+// Hooks into BSScript::Internal::VirtualMachine::AttemptFunctionCall
+// AttemptFunctionCall is called from from BSScript::Internal::VirtualMachine::ProcessMessageQueue
+// 1.5.97: sub_141261CB0
+// 1.6.640: sub_141388580
+// hooks at offset 0x7F (1.6.640 addr: 0x1413885FF)
     REL::Relocation<std::uintptr_t> target{RELOCATION_ID(98130, 104853), REL::VariantOffset(0x7F, 0x7F, 0x7F)};
     _original_func = trampoline.write_call<5>(target.address(), FuncCallHook);
 
@@ -28,47 +33,43 @@ void ProfilingHook::InstallHook() {
     outputLogger->set_pattern("%v");
 }
 
-static RE::BSFixedString* Profiling::FuncCallHook(std::uint64_t unk0, RE::BSScript::Stack* a_stack,
-    std::uint64_t* a_funcCallQuery) {
+static RE::BSFixedString* Profiling::FuncCallHook(
+        RE::BSScript::Internal::VirtualMachine* _this,
+        RE::BSScript::Stack* a_stack,
+        RE::BSTSmartPointer<RE::BSScript::Internal::IFuncCallQuery>& a_funcCallQuery) {
+
     if (numStacksPrinted < stacksPrintCap && a_stack) {
         // Get info from the call
-        RE::BSScript::Internal::IFuncCallQuery::CallType ignore;
+        RE::BSScript::Internal::IFuncCallQuery::CallType callType;
         RE::BSTSmartPointer<RE::BSScript::ObjectTypeInfo> scriptInfo;
-        RE::BSScript::Variable ignore2;
-        RE::BSScrapArray<RE::BSScript::Variable> ignore3;
+        RE::BSScript::Variable self;
+        RE::BSScrapArray<RE::BSScript::Variable> args;
         RE::BSFixedString functionName;
 
         const auto owningTasklet = a_stack->owningTasklet.get();
-        
-        if (owningTasklet && owningTasklet->stack) {
-            // If I don't do the following condition, the GetFunctionCallInfo() call ends up crashing
-            if (owningTasklet->stack->stackType.get() == RE::BSScript::Stack::StackType::kNormal) {
-                owningTasklet->GetFunctionCallInfo(ignore, scriptInfo, functionName, ignore2, ignore3);
+        a_funcCallQuery->GetFunctionCallInfo(callType, scriptInfo, functionName, self, args);
+        if (scriptInfo.get()) {
+            // Print this stack
+            ++numStacksPrinted;
+            std::string stackTrace = std::format("{}.{}", scriptInfo.get()->GetName(), functionName.c_str());
 
-                if (scriptInfo.get()) {
-                    // Print this stack
-                    ++numStacksPrinted;
-                    std::string stackTrace = std::format("{}.{}", scriptInfo.get()->GetName(), functionName.c_str());
-
-                    RE::BSScript::StackFrame* stackFrame = a_stack->top;
-                    if (stackFrame) {
-                        stackFrame = stackFrame->previousFrame;  // Already printed for top, so start with previous
-                        while (stackFrame) {
-                            if (stackFrame->owningFunction && stackFrame->owningFunction.get()) {
-                                const auto scriptName = stackFrame->owningFunction.get()->GetObjectTypeName().c_str();
-                                const auto funcName = stackFrame->owningFunction.get()->GetName().c_str();
-                                stackTrace = std::format("{}.{};", scriptName, funcName) + stackTrace;
-                            }
-                            stackFrame = stackFrame->previousFrame;
-                        }
+            RE::BSScript::StackFrame* stackFrame = a_stack->top;
+            if (stackFrame) {
+                stackFrame = stackFrame->previousFrame;  // Already printed for top, so start with previous
+                while (stackFrame) {
+                    if (stackFrame->owningFunction && stackFrame->owningFunction.get()) {
+                        const auto scriptName = stackFrame->owningFunction.get()->GetObjectTypeName().c_str();
+                        const auto funcName = stackFrame->owningFunction.get()->GetName().c_str();
+                        stackTrace = std::format("{}.{};", scriptName, funcName) + stackTrace;
                     }
-
-                    outputLogger->info(std::format("{} {}", stackTrace, 1));
+                    stackFrame = stackFrame->previousFrame;
                 }
             }
+
+            outputLogger->info(std::format("{} {}", stackTrace, 1));
         }
     }
 
     // Let the engine run its normal code
-    return _original_func(unk0, a_stack, a_funcCallQuery);
+    return _original_func(_this, a_stack, a_funcCallQuery);
 }


### PR DESCRIPTION
`a_stack->OwningTasklet` is just a reference to `a_funcCallQuery` if the `stacktype == kNormal`, and it is empty otherwise, which is why it was crashing before if you didn't check for that.

The function call information for the other stack types, `kPropertyInitialize` and `kInitialize`, can be gotten this way, so we get a fuller picture on the performance impact of object initialization.

I also added .gitattributes so we wouldn't be scammed by CRLF -> LF conversions.