### PR TITLE
Null-check a_funcCallQuery

### DIFF
--- a/src/ProfilingHook.cpp
+++ b/src/ProfilingHook.cpp
@@ -38,7 +38,7 @@ static RE::BSFixedString* Profiling::FuncCallHook(
         RE::BSScript::Stack* a_stack,
         RE::BSTSmartPointer<RE::BSScript::Internal::IFuncCallQuery>& a_funcCallQuery) {
 
-    if (numStacksPrinted < stacksPrintCap && a_stack) {
+    if (numStacksPrinted < stacksPrintCap && a_stack && a_funcCallQuery) {
         // Get info from the call
         RE::BSScript::Internal::IFuncCallQuery::CallType callType;
         RE::BSTSmartPointer<RE::BSScript::ObjectTypeInfo> scriptInfo;


### PR DESCRIPTION
night says we have to null-check this because he blows it out in his FPS fix extension if the stack gets too high. We’re already checking if the stack is at the same level he blows it out, but we should do so anyway.