### PR TITLE
Initial Api Integration

### DIFF
--- a/include/PapyrusAPI.h
+++ b/include/PapyrusAPI.h
@@ -1,0 +1,33 @@
+#pragma once
+#include <RE/Skyrim.h>
+#include <SKSE/SKSE.h>
+
+// Interface code based on https://github.com/adamhynek/higgs
+// Reference for the implementation:
+// https://github.com/Nightfallstorm/DescriptionFramework/blob/main/src/DescriptionFrameworkAPI.h
+
+namespace PapyrusProfilerAPI {
+    constexpr const auto PapyrusProfilerPluginName = "PapyrusProfiler";
+
+    // A message used to fetch PapyrusProfilers's interface
+    struct PapyrusProfilerMessage {
+        enum : uint32_t { kMessage_GetInterface = 0x4ff88a1f };  // Randomly generated
+        void* (*GetApiFunction)(unsigned int revisionNumber) = nullptr;
+    };
+
+    // Returns an IPapyrusProfiler001 object compatible with the API shown below
+    // This should only be called after SKSE sends kMessage_PostLoad to your plugin
+    struct IPapyrusProfilerInterface001;
+    IPapyrusProfilerInterface001* GetPapyrusProfilerInterface001();
+
+    // This object provides access to PapyrusProfiler's mod support API
+    struct IPapyrusProfilerInterface001 {
+        virtual unsigned int GetBuildNumber() = 0;
+
+        virtual void StartProfilingConfig(const std::string& configName) = 0;
+        virtual void StopProfiling() = 0;
+        virtual void LoadSettings() = 0;
+    };
+
+}  // namespace PapyrusProfilerAPI
+extern PapyrusProfilerAPI::IPapyrusProfilerInterface001* g_PapyrusProfilerInterface;

--- a/include/ProfilingConfig.h
+++ b/include/ProfilingConfig.h
@@ -52,6 +52,9 @@ namespace Profiling {
         /** Number of seconds to skip before we actually start recording calls. */
         uint32_t numSkipSeconds = 0;
 
+        /** Show the start / stop debug message box popup. */
+        bool showDebugMessageBox = true;
+
         /** How/when do we want to write data to files? */
         ProfileWriteMode writeMode = ProfileWriteMode::WriteAtEnd;
 

--- a/src/PapyrusAPI.cpp
+++ b/src/PapyrusAPI.cpp
@@ -1,0 +1,29 @@
+#include "PapyrusAPI.h"
+
+// Interface code based on https://github.com/adamhynek/higgs
+// Reference for the implementation:
+// https://github.com/Nightfallstorm/DescriptionFramework/blob/main/src/DescriptionFrameworkAPI.cpp
+
+// Stores the API after it has already been fetched
+PapyrusProfilerAPI::IPapyrusProfilerInterface001* g_PapyrusProfilerInterface = nullptr;
+
+// Fetches the interface to use from PapyrusProfiler
+PapyrusProfilerAPI::IPapyrusProfilerInterface001* PapyrusProfilerAPI::GetPapyrusProfilerInterface001() {
+    // If the interface has already been fetched, return the same object
+    if (g_PapyrusProfilerInterface) {
+        return g_PapyrusProfilerInterface;
+    }
+
+    // Dispatch a message to get the plugin interface from PapyrusProfiler
+    PapyrusProfilerMessage message;
+    const auto skseMessaging = SKSE::GetMessagingInterface();
+    skseMessaging->Dispatch(PapyrusProfilerMessage::kMessage_GetInterface, (void*)&message,
+                            sizeof(PapyrusProfilerMessage*), PapyrusProfilerPluginName);
+    if (!message.GetApiFunction) {
+        return nullptr;
+    }
+
+    // Fetch the API for this version of the PapyrusProfiler interface
+    g_PapyrusProfilerInterface = static_cast<IPapyrusProfilerInterface001*>(message.GetApiFunction(1));
+    return g_PapyrusProfilerInterface;
+}

--- a/src/ProfilingConfig.cpp
+++ b/src/ProfilingConfig.cpp
@@ -84,6 +84,10 @@ void Profiling::ProfilingConfig::PopulateConfig(Profiling::ProfilingConfig& conf
         config.numSkipSeconds = jsonData["NumSkipSeconds"];
     }
 
+    if (jsonData.contains("ShowDebugMessageBox")) {
+        config.showDebugMessageBox = jsonData["ShowDebugMessageBox"];
+    }
+
     if (jsonData.contains("WriteMode")) {
         uint32_t writeMode = jsonData["WriteMode"];
         if (writeMode < static_cast<uint32_t>(ProfileWriteMode::Invalid)) {


### PR DESCRIPTION
Introduces a new API for the Papyrus Profiler. The most important changes are the creation of the `PapyrusProfilerAPI` namespace, the addition of the `showDebugMessageBox` configuration option, and the changes to the SKSE messaging interface.

### New API:

* [`include/PapyrusAPI.h`](diffhunk://#diff-c3b34f3967d711246d11d90991f338614d2b5d7220dcbd20c2500ea7a6651175R1-R33): Added a new namespace `PapyrusProfilerAPI` with structures and functions to fetch and use the Papyrus Profiler interface.
* [`src/PapyrusAPI.cpp`](diffhunk://#diff-94bd493f09d02927fb2114fc6a2115e259ba38aa466546b15565a9fe5e8acdb9R1-R29): Implemented the functions to fetch the Papyrus Profiler interface and handle SKSE messages.
* [`src/Main.cpp`](diffhunk://#diff-f37ae25f3043274d60bcf452a6857c754c4016daa6a0bbbf56d0a6c05264be74R2-R63): Integrated the new Papyrus Profiler API and added a message handler for SKSE messages. [[1]](diffhunk://#diff-f37ae25f3043274d60bcf452a6857c754c4016daa6a0bbbf56d0a6c05264be74R2-R63) [[2]](diffhunk://#diff-f37ae25f3043274d60bcf452a6857c754c4016daa6a0bbbf56d0a6c05264be74R125-R131)
* 
### Profiling Configuration Changes (JSON):

* [`include/ProfilingConfig.h`](diffhunk://#diff-b795a0c4416ba6545222c5c7ae454f9cf884c5dcfcbeadb078a187e8ecc7e7fbR55-R57): Added a new configuration option `showDebugMessageBox` to control the display of debug message boxes.
* [`src/ProfilingConfig.cpp`](diffhunk://#diff-327b5814a7ce8ebb7b2be59c80983a611d66040eabc6d3ebf44f5c8ca30a55b7R87-R90): Updated the `PopulateConfig` function to include the new `showDebugMessageBox` option.
* [`src/ProfilingHook.cpp`](diffhunk://#diff-96363947351aff25d38114c634e3c0d2d0778e5d50249c9922b6ab350a72978bR48-R51): Updated the profiling hooks to respect the `showDebugMessageBox` configuration option, displaying messages when profiling starts and stops. [[1]](diffhunk://#diff-96363947351aff25d38114c634e3c0d2d0778e5d50249c9922b6ab350a72978bR48-R51) [[2]](diffhunk://#diff-96363947351aff25d38114c634e3c0d2d0778e5d50249c9922b6ab350a72978bR146-R151) [[3]](diffhunk://#diff-96363947351aff25d38114c634e3c0d2d0778e5d50249c9922b6ab350a72978bL248-R258)


**Reason**: To enable the ability for users of the API to track and control the state of PapyrusProfiler themself. When using the API, this popup can get in the way. (e.g. I call `StartProfiling` from my plugin's GUI, In the background, this popup appears...)  If you'd like, I could add this directly to the API instead of the profiler config object. That way it's not part of the JSON configuration, and you don't feel the need to update documentation.

### Testing

Built and tested on both `debug-msvc` and `release-msvc` configurations on Skyrim game version 1.6.1170 (STEAM). Although, I did notice when building for msvc-release, the output is in the "release-msvc\Debug\" build directory. Not sure if that's normal.

### Comments

You don't have to approve, merge, and/or close this quite yet. This is the initial implementation with some of the core functions. If you don't mind, I'd like to get deeper into the implementation of this with Modex before approving it and updating it on Nexus. That way I don't have to constantly bug you for PR's and updates. Just wanted to post this PR to make sure I'm in-line with your expectations.